### PR TITLE
fix: stabilize Zed sessions and preset labels

### DIFF
--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -199,6 +199,8 @@ interface SessionRecord {
     preset?: string;
     cancelled: boolean;
     inflight: Inflight | undefined;
+    /** Serializes agent rebuilds requested concurrently by ACP clients. */
+    mutationTail: Promise<void>;
 }
 
 function invalidParams(detail: string): RequestError {
@@ -555,6 +557,13 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
         }
         // Approval policy is agent-scoped state; re-apply it to the new agent.
         setApprovalPolicy(record, record.approvals);
+    };
+
+    /** Run one agent-rebuilding mutation after earlier mutations for this session. */
+    const mutateSession = (record: SessionRecord, mutation: () => Promise<void>): Promise<void> => {
+        const run = record.mutationTail.then(mutation);
+        record.mutationTail = run.catch(() => undefined);
+        return run;
     };
 
     /**
@@ -1395,7 +1404,7 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
         }
         const target = matches[0] as { value: string; label: string };
         if (target.value === currentValue) return `already on ${target.label}`;
-        await switchModel(record, acpSessionId, target.value);
+        await mutateSession(record, () => switchModel(record, acpSessionId, target.value));
         publishCommands(acpSessionId, record);
         publishConfigOptions(acpSessionId, record);
         return `model → ${target.label}`;
@@ -1446,6 +1455,7 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
             approvals: modeId === "danger-full-access" ? "never" : "ask",
             cancelled: false,
             inflight: undefined,
+            mutationTail: Promise.resolve(),
         };
         sessions.set(sessionId, record);
         watchSubagentParent(agent);
@@ -1899,7 +1909,7 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
                     }
                     case "agent":
                     case "preset": {
-                        await switchPreset(record, params.sessionId, value);
+                        await mutateSession(record, () => switchPreset(record, params.sessionId, value));
                         break;
                     }
                     case "effort": {
@@ -1940,7 +1950,7 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
                         break;
                     }
                     case "model": {
-                        await switchModel(record, params.sessionId, value);
+                        await mutateSession(record, () => switchModel(record, params.sessionId, value));
                         break;
                     }
                     default:

--- a/src/bridge/presets.ts
+++ b/src/bridge/presets.ts
@@ -44,7 +44,7 @@ const BUILT_IN_PRESET_NAMES: Readonly<Record<string, string>> = {
     standard: "Standard",
     code: "Code",
     minimal: "Minimal",
-    cordis: "Creator",
+    cordis: "Cordis",
 };
 
 /**

--- a/src/bridge/presets.ts
+++ b/src/bridge/presets.ts
@@ -40,14 +40,21 @@ export interface AgentConfigOption {
     options: PresetSelectChoice[] | PresetSelectGroup[];
 }
 
+const BUILT_IN_PRESET_NAMES: Readonly<Record<string, string>> = {
+    standard: "Standard",
+    code: "Code",
+    minimal: "Minimal",
+    cordis: "Creator",
+};
+
 /**
  * Display name for one roster row: the row's own name, else the id.
  * @param preset - roster row.
  * @returns chip / dropdown label.
  */
 export function presetDisplayName(preset: PresetRow): string {
-    if (preset.id === "cordis") return "Creator";
-    if (preset.id === "code") return "Code";
+    const builtInName = BUILT_IN_PRESET_NAMES[preset.id];
+    if (builtInName !== undefined) return builtInName;
     const name = preset.name?.trim();
     return name !== undefined && name.length > 0 ? name : preset.id;
 }

--- a/src/bridge/presets.ts
+++ b/src/bridge/presets.ts
@@ -44,7 +44,7 @@ const BUILT_IN_PRESET_NAMES: Readonly<Record<string, string>> = {
     standard: "Standard",
     code: "Code",
     minimal: "Minimal",
-    cordis: "Cordis",
+    cordis: "Creator",
 };
 
 /**

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -279,6 +279,40 @@ describe("dsh-acp server (e2e smoke)", () => {
         );
     }, 60_000);
 
+    it("keeps a new session registered while Zed applies config defaults concurrently", async () => {
+        const created = (await client.request("session/new", {
+            cwd: workspace,
+            mcpServers: [],
+        })) as Record<string, unknown>;
+        const createdSessionId = created["sessionId"];
+
+        const defaults = Promise.all([
+            client.request("session/set_config_option", {
+                sessionId: createdSessionId,
+                configId: "agent",
+                value: "code",
+            }),
+            client.request("session/set_config_option", {
+                sessionId: createdSessionId,
+                configId: "model",
+                value: "deepseek-v4-pro",
+            }),
+        ]);
+
+        await expect(defaults).resolves.toEqual([expect.any(Object), expect.any(Object)]);
+        await expect(client.request("session/prompt", {
+            sessionId: createdSessionId,
+            prompt: [{ type: "text", text: "/status" }],
+        })).resolves.toMatchObject({ stopReason: "end_turn" });
+        const status = client.updatesFor(String(createdSessionId)).find(
+            (update) =>
+                update["sessionUpdate"] === "agent_message_chunk" &&
+                (update["content"] as { text?: string } | undefined)?.text?.includes("**dsh-acp**"),
+        );
+        expect((status?.["content"] as { text: string }).text).toContain("| Preset | code |");
+        expect((status?.["content"] as { text: string }).text).toContain("| Model | deepseek-v4-pro |");
+    }, 60_000);
+
     it("accepts mcpServers, tolerating dead servers and unknown transports", async () => {
         // failOnStartupError is off: a server that cannot start must not take
         // the session down, and an unsupported transport is skipped. The name

--- a/test/presets.test.ts
+++ b/test/presets.test.ts
@@ -21,7 +21,7 @@ const roster: PresetRow[] = [
 ];
 
 describe("agent config option copy", () => {
-    it("advertises every built-in preset with locale-neutral English names", () => {
+    it("advertises every built-in preset with an English label matching its stable id", () => {
         const option = agentConfigOption(
             [
                 { id: "standard", name: "标准模式" },
@@ -36,13 +36,13 @@ describe("agent config option copy", () => {
             { value: "standard", name: "Standard" },
             { value: "code", name: "Code" },
             { value: "minimal", name: "Minimal" },
-            { value: "cordis", name: "Creator" },
+            { value: "cordis", name: "Cordis" },
         ]);
     });
 
     it("uses the row name, broken reason, and groups system vs user", () => {
-        expect(presetDisplayName({ id: "cordis" })).toBe("Creator");
-        expect(presetDisplayName({ id: "cordis", name: "Cordis" })).toBe("Creator");
+        expect(presetDisplayName({ id: "cordis" })).toBe("Cordis");
+        expect(presetDisplayName({ id: "cordis", name: "创造模式" })).toBe("Cordis");
         expect(presetDescription({ id: "x", description: "hello" })).toBe("hello");
         expect(presetDescription({ id: "x", broken: "no yaml", description: "hello" })).toBe(
             "Broken: no yaml",
@@ -70,7 +70,7 @@ describe("agent config option copy", () => {
             options: Array<{ value: string; name: string }>;
         };
         expect(system.group).toBe("system");
-        expect(system.options[0]).toMatchObject({ value: "cordis", name: "Creator" });
+        expect(system.options[0]).toMatchObject({ value: "cordis", name: "Cordis" });
         expect(option).not.toHaveProperty("category");
         expect(agentConfigOption([roster[0]!], "cordis")).toBeUndefined();
     });

--- a/test/presets.test.ts
+++ b/test/presets.test.ts
@@ -21,16 +21,23 @@ const roster: PresetRow[] = [
 ];
 
 describe("agent config option copy", () => {
-    it("advertises the code preset as locale-neutral Code instead of the internal PTC name", () => {
+    it("advertises every built-in preset with locale-neutral English names", () => {
         const option = agentConfigOption(
             [
                 { id: "standard", name: "标准模式" },
                 { id: "code", name: "PTC 模式" },
+                { id: "minimal", name: "极简模式" },
+                { id: "cordis", name: "Cordis" },
             ],
             "code",
         );
 
-        expect(option?.options[1]).toEqual({ value: "code", name: "Code" });
+        expect(option?.options).toEqual([
+            { value: "standard", name: "Standard" },
+            { value: "code", name: "Code" },
+            { value: "minimal", name: "Minimal" },
+            { value: "cordis", name: "Creator" },
+        ]);
     });
 
     it("uses the row name, broken reason, and groups system vs user", () => {

--- a/test/presets.test.ts
+++ b/test/presets.test.ts
@@ -21,7 +21,7 @@ const roster: PresetRow[] = [
 ];
 
 describe("agent config option copy", () => {
-    it("advertises every built-in preset with an English label matching its stable id", () => {
+    it("advertises the four built-in presets with their fixed English product names", () => {
         const option = agentConfigOption(
             [
                 { id: "standard", name: "标准模式" },
@@ -36,13 +36,17 @@ describe("agent config option copy", () => {
             { value: "standard", name: "Standard" },
             { value: "code", name: "Code" },
             { value: "minimal", name: "Minimal" },
-            { value: "cordis", name: "Cordis" },
+            { value: "cordis", name: "Creator" },
         ]);
     });
 
     it("uses the row name, broken reason, and groups system vs user", () => {
-        expect(presetDisplayName({ id: "cordis" })).toBe("Cordis");
-        expect(presetDisplayName({ id: "cordis", name: "创造模式" })).toBe("Cordis");
+        expect(presetDisplayName({ id: "cordis" })).toBe("Creator");
+        expect(presetDisplayName({ id: "cordis", name: "创造模式" })).toBe("Creator");
+        expect(presetDisplayName({ id: "reviewer", name: "Code Reviewer", trust: "user" })).toBe(
+            "Code Reviewer",
+        );
+        expect(presetDisplayName({ id: "reviewer", name: "  ", trust: "user" })).toBe("reviewer");
         expect(presetDescription({ id: "x", description: "hello" })).toBe("hello");
         expect(presetDescription({ id: "x", broken: "no yaml", description: "hello" })).toBe(
             "Broken: no yaml",
@@ -70,7 +74,7 @@ describe("agent config option copy", () => {
             options: Array<{ value: string; name: string }>;
         };
         expect(system.group).toBe("system");
-        expect(system.options[0]).toMatchObject({ value: "cordis", name: "Cordis" });
+        expect(system.options[0]).toMatchObject({ value: "cordis", name: "Creator" });
         expect(option).not.toHaveProperty("category");
         expect(agentConfigOption([roster[0]!], "cordis")).toBeUndefined();
     });


### PR DESCRIPTION
## Summary

- serialize per-session agent rebuilds so concurrent Zed config defaults cannot race `dispose`/`resume` and unregister a live session
- normalize the four shipped preset labels to `Standard`, `Code`, `Minimal`, and `Creator`
- preserve every other preset's own `name`, falling back to its id only when the name is absent or blank
- cover the concurrent default-setting + immediate next prompt path and preset-label behavior

## Root cause

Zed can apply saved session config defaults concurrently. Both the agent-preset and model switches rebuild the same Harness agent, so concurrent `resume` calls raced; one could fail with `cannot prepare session ... while it is live` and remove the bridge record, producing the subsequent `unknown session` error.

The shipped Harness preset metadata is Chinese (`标准模式`, `PTC 模式`, `极简模式`, `创造模式`). The bridge already overrode only `code` and `cordis`, leaving a mixed Chinese/English picker. ACP v1 separates the stable option `value` from its human-readable `name` but has no locale negotiation, so the four built-in product names are fixed in English while custom presets retain their authored names.

## Verification

- `npm test` — 123 passed, 1 skipped
- `npm run typecheck`
- `git diff --check`

Closes #3
Closes #4