### PR TITLE
fix: reconcile v0.4.15 and guard release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,20 @@ on:
     tags: ["v*"]
 
 jobs:
+  verify-tag:
+    name: verify tag is on main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Fetch main
+        run: git fetch --no-tags origin main:refs/remotes/origin/main
+      - name: Verify release tag commit is on main
+        run: bash scripts/verify-release-tag.sh "$GITHUB_SHA" origin/main
+
   test:
+    needs: verify-tag
     name: test (${{ matrix.os }}, node ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
     strategy:

--- a/README.md
+++ b/README.md
@@ -104,6 +104,21 @@ owns the composition.
 
 There are two independent ways to extend an ACP-backed surface.
 
+To use portable Agent Plugins, Codex plugins, Claude Code plugins, or Pi
+packages through an ACP client, add the
+[Agent Plugins Bridge](https://github.com/openma-ai/dsh-agents-plugins) to the
+same profile:
+
+```sh
+dsh plugin --profile acp add @openma/dsh-agents-plugins-bridge@latest
+```
+
+The Bridge contributes ordinary Host rows. Imported commands, skills, tools,
+hooks, MCP connections, agents, and Pi extensions therefore reach ACP through
+this adapter's existing projections; there is no ACP-specific plugin import
+runtime. The Bridge's Web management panel and MCP Apps HTML renderer remain
+Web surfaces and are not sent over ACP.
+
 ### Extend the Host composition
 
 The ACP adapter rides the Cordis tree that the profile already owns. Add dsh

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ There are two independent ways to extend an ACP-backed surface.
 
 To use portable Agent Plugins, Codex plugins, Claude Code plugins, or Pi
 packages through an ACP client, add the
-[Agent Plugins Bridge](https://github.com/openma-ai/dsh-agents-plugins) to the
+[Agent Plugins Bridge](https://github.com/openma-ai/dsh-agents-plugins-bridge) to the
 same profile:
 
 ```sh
@@ -118,6 +118,13 @@ hooks, MCP connections, agents, and Pi extensions therefore reach ACP through
 this adapter's existing projections; there is no ACP-specific plugin import
 runtime. The Bridge's Web management panel and MCP Apps HTML renderer remain
 Web surfaces and are not sent over ACP.
+
+For extensions that need a session-owned background lifecycle without an open
+terminal UI, use
+[Martty owner](https://github.com/openma-ai/deepseek-harness-tui/blob/main/README.en.md#martty-owner-long-lived-headless-acp--pi-rpc).
+It is a generic ACP `rpc` client: this package remains the server/transport,
+while Martty owns the long-lived Session and explicit startup/shutdown slash
+commands.
 
 ### Extend the Host composition
 

--- a/scripts/verify-release-tag.sh
+++ b/scripts/verify-release-tag.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+tag_commit="${1:-}"
+main_ref="${2:-origin/main}"
+
+if [[ -z "$tag_commit" ]]; then
+    echo "usage: $0 <tag-commit> [main-ref]" >&2
+    exit 2
+fi
+
+if ! git rev-parse --verify --quiet "${tag_commit}^{commit}" >/dev/null; then
+    echo "release tag commit does not exist: $tag_commit" >&2
+    exit 2
+fi
+
+if ! git rev-parse --verify --quiet "${main_ref}^{commit}" >/dev/null; then
+    echo "release main ref does not exist: $main_ref" >&2
+    exit 2
+fi
+
+if ! git merge-base --is-ancestor "$tag_commit" "$main_ref"; then
+    echo "release tags must point to a commit on origin/main: $tag_commit is not contained in $main_ref" >&2
+    exit 1
+fi
+
+echo "release tag commit $tag_commit is contained in $main_ref"

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -87,6 +87,12 @@ import {
 import { openLocalAuthPage, startLocalAuthPage } from "../auth-page.ts";
 import { logDebug, logWarn } from "../log.ts";
 import { buildReplay } from "./history.ts";
+import { LatestPublication } from "./latest-publication.ts";
+import {
+    interactionModeFromClientMeta,
+    type AcpInteractionMode,
+    withInteractionMode,
+} from "./interaction-mode.ts";
 import {
     attachmentIngestOf,
     convertPrompt,
@@ -251,6 +257,7 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
     const { createUserMessage, errorChain, sessionId: SessionId, foldSessionTitle, setSandboxMode } = harness;
     const SANDBOX_MODES = harness.sandboxModes;
     const sessions = new Map<string, SessionRecord>();
+    const commandPublications = new LatestPublication();
     interface LiveSubagent {
         rootSessionId: string;
         childSessionId: string;
@@ -270,6 +277,8 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
     let clientSubagentTranscript = false;
     /** Whether the client can render standard ACP form elicitation. */
     let clientElicitationForm = false;
+    /** Explicit interaction semantics negotiated from ACP client `_meta`. */
+    let clientInteractionMode: AcpInteractionMode | undefined;
     const tuiClient: TuiClientAdvertisement = { advertised: false };
     const rpc = new AcpRpc();
     const findAgent = (agentId: string): Agent | undefined => {
@@ -609,15 +618,16 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
     const agentOptionsFor = (
         model: string | undefined,
         provider?: string,
-    ): { provider?: string; model?: string; maxTokens?: number } => ({
-        ...(provider !== undefined
-            ? { provider }
-            : config.provider !== undefined
-              ? { provider: config.provider }
-              : {}),
-        ...(model !== undefined ? { model } : {}),
-        ...(config.maxTokens !== undefined ? { maxTokens: config.maxTokens } : {}),
-    });
+    ): { provider?: string; model?: string; maxTokens?: number; interactionMode?: AcpInteractionMode } =>
+        withInteractionMode({
+            ...(provider !== undefined
+                ? { provider }
+                : config.provider !== undefined
+                  ? { provider: config.provider }
+                  : {}),
+            ...(model !== undefined ? { model } : {}),
+            ...(config.maxTokens !== undefined ? { maxTokens: config.maxTokens } : {}),
+        }, clientInteractionMode);
 
     /** Return the bridge-owned record for an agent, rejecting same-id impostors. */
     const ownedRecord = (agent: Agent): SessionRecord | undefined => {
@@ -1256,14 +1266,23 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
     const publishCommands = (sessionId: string, record?: SessionRecord): void => {
         const target = record ?? sessions.get(sessionId);
         if (target === undefined) return;
-        void availableCommandsFor(target)
-            .then((availableCommands) => {
+        void commandPublications
+            .run(sessionId, () => availableCommandsFor(target), (availableCommands) => {
+                if (sessions.get(sessionId) !== target) return;
+                logDebug(
+                    `available commands ${sessionId}: ${availableCommands.map((command) => command.name).join(", ")}`,
+                );
                 notify(sessionId, { sessionUpdate: "available_commands_update", availableCommands });
             })
             .catch((error: unknown) => {
                 logWarn(`publishing commands failed: ${String(error)}`);
             });
     };
+
+    ctx.on("commands/change", () => {
+        logDebug(`commands/change: ${sessions.size} live ACP session(s)`);
+        for (const [sessionId, record] of sessions) publishCommands(sessionId, record);
+    });
 
     /** Push the current config-option surface (Zed re-renders its selectors). */
     const publishConfigOptions = (sessionId: string, record: SessionRecord): void => {
@@ -1559,6 +1578,7 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
                     capsMeta !== null && typeof capsMeta === "object"
                         ? capsMeta["subagent-transcript"] === true
                         : false;
+                clientInteractionMode = interactionModeFromClientMeta(capsMeta);
                 clientElicitationForm =
                     params.clientCapabilities?.elicitation?.form !== undefined &&
                     params.clientCapabilities.elicitation.form !== null;

--- a/src/bridge/interaction-mode.ts
+++ b/src/bridge/interaction-mode.ts
@@ -1,0 +1,20 @@
+export type AcpInteractionMode = "interactive" | "rpc";
+
+/** Read only the explicit DSH ACP extension; absence and unknown values stay absent. */
+export function interactionModeFromClientMeta(meta: unknown): AcpInteractionMode | undefined {
+    if (meta === null || typeof meta !== "object") return undefined;
+    const dsh = (meta as Record<string, unknown>)["dsh"];
+    if (dsh === null || typeof dsh !== "object") return undefined;
+    const interaction = (dsh as Record<string, unknown>)["interaction"];
+    if (interaction === null || typeof interaction !== "object") return undefined;
+    const mode = (interaction as Record<string, unknown>)["mode"];
+    return mode === "interactive" || mode === "rpc" ? mode : undefined;
+}
+
+/** Add the negotiated mode without manufacturing one for clients that omitted it. */
+export function withInteractionMode<T extends object>(
+    options: T,
+    mode: AcpInteractionMode | undefined,
+): T & { interactionMode?: AcpInteractionMode } {
+    return mode === undefined ? options : { ...options, interactionMode: mode };
+}

--- a/src/bridge/latest-publication.ts
+++ b/src/bridge/latest-publication.ts
@@ -1,0 +1,21 @@
+/**
+ * Per-key generation gate for async replace-whole-state publications.
+ *
+ * A later snapshot owns the key immediately, not when its producer settles.
+ * This prevents a slower, older read from overwriting a newer catalogue.
+ */
+export class LatestPublication {
+    private readonly revisions = new Map<string, number>();
+
+    async run<T>(key: string, produce: () => Promise<T>, publish: (value: T) => void): Promise<void> {
+        const revision = (this.revisions.get(key) ?? 0) + 1;
+        this.revisions.set(key, revision);
+        const value = await produce();
+        if (this.revisions.get(key) !== revision) return;
+        publish(value);
+    }
+
+    invalidate(key: string): void {
+        this.revisions.set(key, (this.revisions.get(key) ?? 0) + 1);
+    }
+}

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -60,8 +60,10 @@ export class HarnessNotFoundError extends Error {
     }
 }
 
-/** The package whose presence marks a usable harness tree. */
+/** The runtime package whose version describes the resolved harness tree. */
 const ANCHOR = "@deepseek-ai/dsh-agent";
+/** Profile boot requires the launcher package in the same resolvable tree. */
+const PROFILE_LAUNCHER = "@deepseek-ai/dsh";
 
 function packageDirFrom(base: string, name: string): string | undefined {
     // Node's ascending node_modules walk, starting at `base`.
@@ -91,7 +93,8 @@ function versionOf(packageDir: string): string | undefined {
 
 function hostAt(base: string, source: string): HarnessHost | undefined {
     const anchor = packageDirFrom(base, ANCHOR);
-    if (anchor === undefined) return undefined;
+    const launcher = packageDirFrom(base, PROFILE_LAUNCHER);
+    if (anchor === undefined || launcher === undefined) return undefined;
     return { base: resolve(base), version: versionOf(anchor), source };
 }
 

--- a/test/ci-workflows.test.ts
+++ b/test/ci-workflows.test.ts
@@ -5,7 +5,11 @@ import { describe, expect, it } from "vitest";
 
 interface Workflow {
     jobs?: {
+        "verify-tag"?: {
+            steps?: Array<{ run?: string }>;
+        };
         test?: {
+            needs?: unknown;
             strategy?: {
                 matrix?: {
                     os?: unknown;
@@ -15,13 +19,29 @@ interface Workflow {
     };
 }
 
-function testRunners(workflow: string): unknown {
+function readWorkflow(workflow: string): Workflow {
     const source = readFileSync(join(import.meta.dirname, "../.github/workflows", workflow), "utf8");
-    return (parse(source) as Workflow).jobs?.test?.strategy?.matrix?.os;
+    return parse(source) as Workflow;
+}
+
+function testRunners(workflow: string): unknown {
+    return readWorkflow(workflow).jobs?.test?.strategy?.matrix?.os;
 }
 
 describe("supported CI architectures", () => {
     it.each(["ci.yml", "release.yml"])("runs %s tests on native Linux ARM64", (workflow) => {
         expect(testRunners(workflow)).toContain("ubuntu-24.04-arm");
+    });
+});
+
+describe("release provenance", () => {
+    it("gates release tests on verifying that the tag commit belongs to main", () => {
+        const jobs = readWorkflow("release.yml").jobs;
+        const guardCommands = jobs?.["verify-tag"]?.steps?.flatMap((step) => step.run ?? []);
+
+        expect(jobs?.test?.needs).toBe("verify-tag");
+        expect(guardCommands).toContain(
+            'bash scripts/verify-release-tag.sh "$GITHUB_SHA" origin/main',
+        );
     });
 });

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -193,6 +193,93 @@ describe("dsh-acp bundle overlays", () => {
     }, 90_000);
 });
 
+describe("dsh-acp live command catalogue", () => {
+    let client: AcpTestClient;
+    const roots: string[] = [];
+
+    afterAll(async () => {
+        await client?.close();
+        for (const root of roots) rmSync(root, { recursive: true, force: true });
+    });
+
+    it("republishes commands registered after session creation", async () => {
+        const sessionRoot = mkdtempSync(join(tmpdir(), "dsh-acp-command-change-sessions-"));
+        const workspace = mkdtempSync(join(tmpdir(), "dsh-acp-command-change-workspace-"));
+        const bundle = mkdtempSync(join(tmpdir(), "dsh-acp-command-change-bundle-"));
+        const trigger = join(bundle, "register-late-command");
+        roots.push(sessionRoot, workspace, bundle);
+        writeFileSync(join(bundle, "package.json"), JSON.stringify({
+            name: "dsh-acp-test-command-change",
+            type: "module",
+            main: "./index.js",
+            dsh: { bundle: { patch: "./cordis.patch.yml" } },
+        }));
+        writeFileSync(join(bundle, "cordis.patch.yml"), JSON.stringify([{
+            insert: [{
+                id: "dsh-acp-test-command-change",
+                name: "dsh-acp-test-command-change",
+                config: { trigger },
+            }],
+        }]));
+        writeFileSync(join(bundle, "index.js"), [
+            "import { existsSync } from 'node:fs'",
+            "export const inject = ['agents']",
+            "export function apply(ctx, config) {",
+            "  const timers = new Set()",
+            "  ctx.on('agent/created', ({ agent }) => {",
+            "    const timer = setInterval(() => {",
+            "      if (!existsSync(config.trigger)) return",
+            "      clearInterval(timer)",
+            "      timers.delete(timer)",
+            "      agent.ctx.inject(['commands'], commandCtx => commandCtx.commands.register({",
+            "        name: 'late-fixture-command',",
+            "        description: 'Registered after the ACP session snapshot',",
+            "        handler: () => ({ kind: 'success', text: 'late command ready' }),",
+            "      }))",
+            "    }, 20)",
+            "    timers.add(timer)",
+            "  })",
+            "  ctx.effect(() => () => { for (const timer of timers) clearInterval(timer) })",
+            "}",
+        ].join("\n"));
+
+        client = new AcpTestClient(
+            sessionRoot,
+            workspace,
+            undefined,
+            undefined,
+            ["--bundle", bundle],
+        );
+        await client.request("initialize", { protocolVersion: 1 }, 60_000);
+        const created = await client.request("session/new", { cwd: workspace, mcpServers: [] }) as {
+            sessionId: string;
+        };
+
+        let initialNames: string[] = [];
+        for (let attempt = 0; attempt < 80; attempt += 1) {
+            const update = [...client.updatesFor(created.sessionId)]
+                .reverse()
+                .find((entry) => entry["sessionUpdate"] === "available_commands_update");
+            initialNames = ((update?.["availableCommands"] ?? []) as Array<{ name: string }>).map(({ name }) => name);
+            if (initialNames.length > 0) break;
+            await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+        expect(initialNames).not.toContain("late-fixture-command");
+
+        writeFileSync(trigger, "register");
+        let liveNames = initialNames;
+        for (let attempt = 0; attempt < 120; attempt += 1) {
+            const update = [...client.updatesFor(created.sessionId)]
+                .reverse()
+                .find((entry) => entry["sessionUpdate"] === "available_commands_update");
+            liveNames = ((update?.["availableCommands"] ?? []) as Array<{ name: string }>).map(({ name }) => name);
+            if (liveNames.includes("late-fixture-command")) break;
+            await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+        expect(liveNames).toContain("late-fixture-command");
+    }, 90_000);
+});
+
 describe("dsh-acp server (e2e smoke)", () => {
     let client: AcpTestClient;
     let sessionRoot: string;

--- a/test/harness.test.ts
+++ b/test/harness.test.ts
@@ -24,6 +24,7 @@ afterAll(() => {
 describe("resolveHost", () => {
     it("accepts a directory whose node_modules carries the harness", () => {
         const root = makeTree();
+        writePackage(join(root, "node_modules", "@deepseek-ai", "dsh"), "@deepseek-ai/dsh");
         writePackage(join(root, "node_modules", "@deepseek-ai", "dsh-agent"), "@deepseek-ai/dsh-agent");
         const host = resolveHost(root);
         expect(host.base).toBe(root);
@@ -33,6 +34,10 @@ describe("resolveHost", () => {
 
     it("accepts an npm prefix (lib/node_modules layout)", () => {
         const root = makeTree();
+        writePackage(
+            join(root, "lib", "node_modules", "@deepseek-ai", "dsh"),
+            "@deepseek-ai/dsh",
+        );
         writePackage(
             join(root, "lib", "node_modules", "@deepseek-ai", "dsh-agent"),
             "@deepseek-ai/dsh-agent",
@@ -62,6 +67,12 @@ describe("resolveHost", () => {
         const root = makeTree();
         expect(() => resolveHost(root)).toThrow(HarnessNotFoundError);
         expect(() => resolveHost(root)).toThrow(/npm install -g @deepseek-ai\/dsh/);
+    });
+
+    it("rejects a partial module tree that has dsh-agent but not the dsh profile launcher", () => {
+        const root = makeTree();
+        writePackage(join(root, "node_modules", "@deepseek-ai", "dsh-agent"), "@deepseek-ai/dsh-agent");
+        expect(() => resolveHost(root)).toThrow(HarnessNotFoundError);
     });
 
     it("auto-detects a harness from the checkout when no path is given", () => {

--- a/test/interaction-mode.test.ts
+++ b/test/interaction-mode.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    interactionModeFromClientMeta,
+    withInteractionMode,
+} from "../src/bridge/interaction-mode.ts";
+
+describe("ACP client interaction mode", () => {
+    it("carries only an explicit client mode into Agent options", () => {
+        expect(interactionModeFromClientMeta({
+            dsh: { interaction: { mode: "rpc" } },
+        })).toBe("rpc");
+        expect(interactionModeFromClientMeta({
+            dsh: { interaction: { mode: "interactive" } },
+        })).toBe("interactive");
+        expect(interactionModeFromClientMeta({})).toBeUndefined();
+        expect(interactionModeFromClientMeta({
+            dsh: { interaction: { mode: "headless" } },
+        })).toBeUndefined();
+
+        expect(withInteractionMode({ model: "fixture" }, "rpc")).toEqual({
+            model: "fixture",
+            interactionMode: "rpc",
+        });
+        expect(withInteractionMode({ model: "fixture" }, undefined)).toEqual({
+            model: "fixture",
+        });
+    });
+});

--- a/test/latest-publication.test.ts
+++ b/test/latest-publication.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { LatestPublication } from "../src/bridge/latest-publication.js";
+
+describe("LatestPublication", () => {
+    it("drops an older async snapshot that resolves after the latest one", async () => {
+        const publications = new LatestPublication();
+        const delivered: string[] = [];
+        let resolveOld!: (value: string) => void;
+        const oldValue = new Promise<string>((resolve) => {
+            resolveOld = resolve;
+        });
+
+        const old = publications.run("session", () => oldValue, (value) => delivered.push(value));
+        const latest = publications.run("session", async () => "latest", (value) => delivered.push(value));
+        await latest;
+        resolveOld("stale");
+        await old;
+
+        expect(delivered).toEqual(["latest"]);
+    });
+
+    it("invalidates an in-flight snapshot when its session is retired", async () => {
+        const publications = new LatestPublication();
+        const delivered: string[] = [];
+        let resolve!: (value: string) => void;
+        const value = new Promise<string>((done) => {
+            resolve = done;
+        });
+
+        const pending = publications.run("session", () => value, (entry) => delivered.push(entry));
+        publications.invalidate("session");
+        resolve("retired");
+        await pending;
+
+        expect(delivered).toEqual([]);
+    });
+});

--- a/test/release-tag-guard.test.ts
+++ b/test/release-tag-guard.test.ts
@@ -1,0 +1,55 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+
+const GUARD = join(import.meta.dirname, "../scripts/verify-release-tag.sh");
+const roots: string[] = [];
+
+function git(cwd: string, ...args: string[]): string {
+    const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+    expect(result.status, result.stderr).toBe(0);
+    return result.stdout.trim();
+}
+
+function commit(cwd: string, file: string, contents: string, message: string): string {
+    writeFileSync(join(cwd, file), contents);
+    git(cwd, "add", "--", file);
+    git(cwd, "commit", "-m", message);
+    return git(cwd, "rev-parse", "HEAD");
+}
+
+describe("release tag ancestry guard", () => {
+    afterEach(() => {
+        for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+    });
+
+    it("accepts main commits and rejects commits that only exist on a side branch", () => {
+        const repo = mkdtempSync(join(tmpdir(), "dsh-acp-release-tag-"));
+        roots.push(repo);
+        git(repo, "init", "-b", "main");
+        git(repo, "config", "user.name", "Release Guard Test");
+        git(repo, "config", "user.email", "release-guard@example.invalid");
+        commit(repo, "base.txt", "base\n", "base");
+
+        git(repo, "switch", "-c", "side");
+        const sideCommit = commit(repo, "side.txt", "side\n", "side release");
+        git(repo, "switch", "main");
+        const mainCommit = commit(repo, "main.txt", "main\n", "main release");
+        git(repo, "update-ref", "refs/remotes/origin/main", mainCommit);
+
+        const accepted = spawnSync("bash", [GUARD, mainCommit, "origin/main"], {
+            cwd: repo,
+            encoding: "utf8",
+        });
+        const rejected = spawnSync("bash", [GUARD, sideCommit, "origin/main"], {
+            cwd: repo,
+            encoding: "utf8",
+        });
+
+        expect(accepted.status, accepted.stderr).toBe(0);
+        expect(rejected.status).not.toBe(0);
+        expect(rejected.stderr).toContain("release tags must point to a commit on origin/main");
+    });
+});


### PR DESCRIPTION
## Summary

- bring the commits already published as npm v0.4.15 back onto main
- preserve the Zed session and preset fixes merged in #5
- block release tags whose commits are not contained in `origin/main`
- cover the ancestry guard and workflow dependency with tests

## Why

`v0.4.15` was created from a side branch, so npm contained code that was absent from main. The tag cannot be republished or safely moved. This reconciles that history, then lets us publish the combined main-line state as v0.4.16.

## Validation

- `npm test` (130 passed, 1 skipped)
- `npm run typecheck`
- `git diff --check`