### PR TITLE
fix: accept current dsh prerelease host

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "node": ">=22.15"
       },
       "peerDependencies": {
-        "@deepseek-ai/dsh": "^0.1.0-rc.6"
+        "@deepseek-ai/dsh": "^0.1.0-rc.6 || ^0.1.1-rc.1"
       }
     },
     "node_modules/@agentclientprotocol/sdk": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@deepseek-ai/dsh": "^0.1.0-rc.6"
+    "@deepseek-ai/dsh": "^0.1.0-rc.6 || ^0.1.1-rc.1"
   },
   "exports": {
     ".": "./dist/index.js",

--- a/test/package-manifest.test.ts
+++ b/test/package-manifest.test.ts
@@ -13,7 +13,7 @@ describe("ACP package manifest", () => {
             zod: "^4.4.3",
         });
         expect(manifest.peerDependencies).toEqual({
-            "@deepseek-ai/dsh": "^0.1.0-rc.6",
+            "@deepseek-ai/dsh": "^0.1.0-rc.6 || ^0.1.1-rc.1",
         });
     });
 });

--- a/test/profile-install.test.ts
+++ b/test/profile-install.test.ts
@@ -256,6 +256,24 @@ describe.skipIf(process.platform === "win32")("ACP package installation", () => 
         expect(`${installed.stdout}\n${installed.stderr}`).toMatch(/ERESOLVE|conflicting peer dependency/i);
     }, INSTALL_TIMEOUT_MS);
 
+    it("accepts the current 0.1.1 prerelease host under strict peer resolution", () => {
+        const prefix = mkdtempSync(join(tmpdir(), "dsh-acp-current-prefix-"));
+        roots.push(prefix);
+        const installed = run("npm", [
+            "install",
+            "--prefix",
+            prefix,
+            "--ignore-scripts",
+            "--no-audit",
+            "--no-fund",
+            "--strict-peer-deps",
+            "@deepseek-ai/dsh@0.1.1-rc.2",
+            `file:${tarball}`,
+        ]);
+
+        expect(installed.status, `${installed.stdout}\n${installed.stderr}`).toBe(0);
+    }, INSTALL_TIMEOUT_MS);
+
     it("serves ACP after installation into a dsh profile", async () => {
         const home = mkdtempSync(join(tmpdir(), "dsh-acp-profile-runtime-"));
         roots.push(home);


### PR DESCRIPTION
## Summary
- extend the required dsh peer across the supported 0.1.0 and 0.1.1 prerelease lines
- prove `dsh@0.1.1-rc.2` installs with ACP under strict peer resolution
- retain rc.6 as the development and minimum compatibility host

## Tests
- `npm test`
- `npm exec vitest -- run test/package-manifest.test.ts`
- `npm exec vitest -- run test/profile-install.test.ts -t "accepts the current 0.1.1 prerelease host"`
- `git diff --check`