### PR TITLE
fix: propagate default model to subagents

### DIFF
--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -643,16 +643,16 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
     const agentOptionsFor = (
         model: string | undefined,
         provider?: string,
-    ): { provider?: string; model?: string; maxTokens?: number; interactionMode?: AcpInteractionMode } =>
-        withInteractionMode({
-            ...(provider !== undefined
-                ? { provider }
-                : config.provider !== undefined
-                  ? { provider: config.provider }
-                  : {}),
-            ...(model !== undefined ? { model } : {}),
+    ): { provider?: string; model?: string; maxTokens?: number; interactionMode?: AcpInteractionMode } => {
+        const defaults = defaultSelection();
+        const resolvedProvider = provider ?? config.provider ?? defaults.provider;
+        const resolvedModel = model ?? config.model ?? defaults.model;
+        return withInteractionMode({
+            ...(resolvedProvider !== undefined ? { provider: resolvedProvider } : {}),
+            ...(resolvedModel !== undefined ? { model: resolvedModel } : {}),
             ...(config.maxTokens !== undefined ? { maxTokens: config.maxTokens } : {}),
         }, clientInteractionMode);
+    };
 
     /** Return the bridge-owned record for an agent, rejecting same-id impostors. */
     const ownedRecord = (agent: Agent): SessionRecord | undefined => {

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -291,6 +291,60 @@ describe("dsh-acp Host-owned defaults", () => {
         await Promise.all(clients.map((entry) => entry.close()));
         for (const root of roots) rmSync(root, { recursive: true, force: true });
     });
+
+    it("materializes the Host default route on the parent agent for subagent inheritance", async () => {
+        const sessionRoot = mkdtempSync(join(tmpdir(), "dsh-acp-inherited-model-sessions-"));
+        const workspace = mkdtempSync(join(tmpdir(), "dsh-acp-inherited-model-workspace-"));
+        const bundle = mkdtempSync(join(tmpdir(), "dsh-acp-inherited-model-bundle-"));
+        const marker = join(bundle, "agent-options.json");
+        roots.push(sessionRoot, workspace, bundle);
+
+        const harnessHome = join(sessionRoot, "home");
+        mkdirSync(harnessHome, { recursive: true });
+        writeFileSync(
+            join(harnessHome, "settings.yaml"),
+            "agent-default-model:\n  provider: deepseek-official\n  model: deepseek-v4-pro\n",
+        );
+        writeFileSync(join(bundle, "package.json"), JSON.stringify({
+            name: "dsh-acp-test-agent-options",
+            type: "module",
+            main: "./index.js",
+            dsh: { bundle: { patch: "./cordis.patch.yml" } },
+        }));
+        writeFileSync(join(bundle, "cordis.patch.yml"), JSON.stringify([{
+            insert: [{
+                id: "dsh-acp-test-agent-options",
+                name: "dsh-acp-test-agent-options",
+                config: { marker },
+            }],
+        }]));
+        writeFileSync(join(bundle, "index.js"), [
+            "import { writeFileSync } from 'node:fs'",
+            "export const inject = ['agents']",
+            "export function apply(ctx, config) {",
+            "  ctx.on('agent/created', ({ agent }) => {",
+            "    if (agent.session.header.parentSession === undefined) {",
+            "      writeFileSync(config.marker, JSON.stringify(agent.options))",
+            "    }",
+            "  })",
+            "}",
+        ].join("\n"));
+
+        const client = new AcpTestClient(
+            sessionRoot,
+            workspace,
+            undefined,
+            undefined,
+            ["--bundle", bundle],
+        );
+        clients.push(client);
+
+        await client.request("initialize", { protocolVersion: 1 }, 60_000);
+        await client.request("session/new", { cwd: workspace, mcpServers: [] });
+
+        expect(JSON.parse(readFileSync(marker, "utf8")))
+            .toMatchObject({ provider: "deepseek-official", model: "deepseek-v4-pro" });
+    }, 90_000);
 
     it("saves the selected model and effort as the default for later sessions", async () => {
         const sessionRoot = mkdtempSync(join(tmpdir(), "dsh-acp-default-model-sessions-"));


### PR DESCRIPTION
## Summary

- materialize the Host default provider/model in ACP-created agent options
- allow in-process subagents to inherit the parent model route
- add an end-to-end regression test covering Host-default inheritance

## Root cause

ACP applied the Host default model through the mutable model-selection hook, but left `parent.options.provider` and `parent.options.model` empty. The DSH subagent driver inherits its route from those parent options, so child prompt assembly failed while resolving `{{model}}`.

## Verification

- `npm run typecheck`
- `npm test` (140 passed, 1 skipped)