### PR TITLE
Preserve DSH tool result values in ACP metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,52 @@ Optional wire behavior follows ACP's extension conventions:
    extension must still get normal sessions, prompts, updates, cancellation,
    auth, and config options.
 
+#### DSH tool result values
+
+For a successful DSH tool execution, a `tool_call_update` may include the
+tool's native structured return value before DSH renders it for the model:
+
+```json
+{
+  "sessionUpdate": "tool_call_update",
+  "toolCallId": "call_123",
+  "status": "completed",
+  "content": [
+    {
+      "type": "content",
+      "content": {
+        "type": "text",
+        "text": "```sh\nstarted background job bash-1\n```\n"
+      }
+    }
+  ],
+  "rawOutput": {
+    "output": "started background job bash-1",
+    "isError": false
+  },
+  "_meta": {
+    "dsh": {
+      "toolResult": {
+        "value": {
+          "kind": "background",
+          "jobId": "bash-1"
+        }
+      }
+    }
+  }
+}
+```
+
+`content` and `rawOutput` remain the standard, normalized ACP result and are
+complete for ordinary clients. `_meta.dsh.toolResult.value` is an optional
+machine-readable DSH value for clients that need native handles such as a
+background `jobId`; it is not a second model-visible result. Live updates use
+the exact value observed from DSH's `tools/result` event. DSH deliberately
+does not persist that execution-local value, so history replay restores this
+metadata only for recognized background-job and continuable-subagent
+acknowledgements. Clients must therefore treat the metadata as optional and
+ignore unknown fields under `_meta`.
+
 The current package applies this pattern to the built-in `_dsh/cordis/*`
 family used by the TUI for Client capability discovery, dynamic Package
 lifecycle, and package-private Host/Client RPC. It is an explicit, versioned

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -67,6 +67,7 @@ import type {} from "@deepseek-ai/dsh-skill";
 import type {} from "@deepseek-ai/dsh-agent-default-model";
 import { PERMISSION_SETTINGS_NAMESPACE } from "@deepseek-ai/dsh-permission-presets";
 import type {} from "@deepseek-ai/dsh-agent-presets";
+import type {} from "@deepseek-ai/dsh-tools";
 import type { SubagentRunEndInfo, SubagentRunInfo } from "@deepseek-ai/dsh-subagent";
 
 import { VERSION } from "../version.ts";
@@ -1549,6 +1550,19 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
     // ------------------------------------------------------------------ //
     // Live event routing                                                  //
     // ------------------------------------------------------------------ //
+
+    // DSH intentionally omits structured tool values from durable session events.
+    // Observe the finalized execution result one layer earlier and stage its value
+    // by call id so the following `tool/result` projection can publish it as
+    // generic ACP metadata. Nested Code Mode dispatches have no matching
+    // top-level ACP tool call and therefore stay on their own log surface.
+    ctx.on("tools/result", (exec, result) => {
+        if (exec.parent !== undefined || exec.agent === undefined || result.isError) return;
+        const projection =
+            ownedRecord(exec.agent)?.projection
+            ?? subagentByChild.get(String(exec.agent.session.id))?.projection;
+        projection?.recordToolResult(String(exec.callId), result.value);
+    });
 
     ctx.on("session/event", (session, event: SessionEvent) => {
         const sessionId = String(session.header.id);

--- a/src/bridge/translate.ts
+++ b/src/bridge/translate.ts
@@ -201,6 +201,35 @@ interface ToolResultFacts {
     diffs: FileDiffMeta[];
 }
 
+function acknowledgementId(text: string, prefix: string): string | undefined {
+    if (!text.startsWith(prefix)) return undefined;
+    const id = text.slice(prefix.length);
+    if (id.length === 0 || id.trim() !== id || id.includes(" ") || id.includes("\t") || id.includes("\n")) {
+        return undefined;
+    }
+    return id;
+}
+
+/** Restore typed handles from DSH's documented background-result renderings. */
+function typedToolAcknowledgement(
+    state: ProjectedToolCall | undefined,
+    text: string,
+    failed: boolean,
+): Record<string, unknown> | undefined {
+    if (state === undefined || failed) return undefined;
+    if (state.name === "bash" || state.name === "pwsh") {
+        const jobId = acknowledgementId(text, "started background job ");
+        return jobId === undefined ? undefined : { kind: "background", jobId };
+    }
+    if (state.name === "subagent") {
+        const jobId = acknowledgementId(text, "started background subagent job ");
+        if (jobId !== undefined) return { kind: "background", jobId };
+        const subagentId = acknowledgementId(text, "started subagent ");
+        if (subagentId !== undefined) return { kind: "continuable", subagentId };
+    }
+    return undefined;
+}
+
 function extractToolResult(data: Record<string, unknown>): ToolResultFacts {
     let failed = data["error"] !== undefined && data["error"] !== null;
     const parts: string[] = [];
@@ -405,6 +434,8 @@ export class SessionProjection {
 
     private streamedText = new Set<string>();
     private streamedReasoning = new Set<string>();
+    /** Structured tool values observed live before DSH omits them from its durable event. */
+    private toolResultValues = new Map<string, unknown>();
     /** One authoritative state per open ACP tool call. Block indexes only
      * route streaming fragments to that state; they never own lifecycle. */
     private toolCalls = new Map<string, ProjectedToolCall>();
@@ -432,6 +463,11 @@ export class SessionProjection {
         this.cwd = options?.cwd;
         this.presentCall = options?.presentCall;
         this.subagent = options?.subagent;
+    }
+
+    /** Stage one live `tools/result` value for the matching durable `tool/result` event. */
+    recordToolResult(callId: string, value: unknown): void {
+        this.toolResultValues.set(callId, value);
     }
 
     /** Reset per-prompt accumulators; call when a new `session/prompt` starts. */
@@ -913,6 +949,21 @@ export class SessionProjection {
         const state = this.toolCalls.get(callId);
         const facts = state?.facts;
         const { failed, text, diffs } = extractToolResult(data);
+        const hasLiveValue = this.toolResultValues.has(callId);
+        const liveValue = this.toolResultValues.get(callId);
+        this.toolResultValues.delete(callId);
+        const toolResultValue = hasLiveValue ? liveValue : typedToolAcknowledgement(state, text, failed);
+        const toolResultMeta =
+            toolResultValue === undefined
+                ? undefined
+                : {
+                      dsh: {
+                          toolResult: {
+                              value: toolResultValue,
+                          },
+                      },
+                  };
+        const rawOutput = text.length > 0 ? { output: text, isError: failed } : undefined;
         const content: ToolCallContent[] = diffs.map((diff) => ({
             type: "diff",
             path: diff.path,
@@ -942,8 +993,9 @@ export class SessionProjection {
                     sessionUpdate: "tool_call_update",
                     toolCallId: callId,
                     status: failed ? "failed" : "completed",
-                    ...(text.length > 0 ? { rawOutput: { output: text, isError: failed } } : {}),
+                    ...(rawOutput !== undefined ? { rawOutput } : {}),
                     _meta: {
+                        ...(toolResultMeta ?? {}),
                         terminal_exit: { terminal_id: callId, exit_code: failed ? 1 : 0, signal: null },
                     },
                 } as unknown as SessionUpdate,
@@ -968,7 +1020,8 @@ export class SessionProjection {
                 toolCallId: callId,
                 status: failed ? "failed" : "completed",
                 ...(content.length > 0 ? { content } : {}),
-                ...(text.length > 0 ? { rawOutput: { output: text, isError: failed } } : {}),
+                ...(rawOutput !== undefined ? { rawOutput } : {}),
+                ...(toolResultMeta !== undefined ? { _meta: toolResultMeta } : {}),
             },
         ];
     }
@@ -986,6 +1039,7 @@ export class SessionProjection {
         }
         this.toolCallBlocks.clear();
         this.toolCalls.clear();
+        this.toolResultValues.clear();
         // A stopped prompt turn owns presentation settlement for any orphaned
         // calls. Do not rewrite `pending`/`in_progress` into a fabricated ACP
         // failure; clients already have the authoritative prompt boundary.

--- a/test/translate.test.ts
+++ b/test/translate.test.ts
@@ -524,6 +524,107 @@ describe("SessionProjection tool calls", () => {
         });
     });
 
+    it.each([
+        {
+            name: "bash",
+            arguments: '{"command":"sleep 4","run_in_background":true}',
+            text: "started background job bash-1",
+            typed: { kind: "background", jobId: "bash-1" },
+        },
+        {
+            name: "subagent",
+            arguments: '{"description":"check","prompt":"inspect","run_in_background":true}',
+            text: "started background subagent job subagent-2",
+            typed: { kind: "background", jobId: "subagent-2" },
+        },
+        {
+            name: "subagent",
+            arguments: '{"description":"check","prompt":"inspect"}',
+            text: "started subagent child-3",
+            typed: { kind: "continuable", subagentId: "child-3" },
+        },
+    ])("publishes the typed $typed.kind fallback for $name acknowledgements", ({ name, arguments: args, text, typed }) => {
+        const p = new SessionProjection();
+        p.onEvent(event("tool/call", { turn: 1, step: 0, callId: "background-call", name, arguments: args }));
+
+        const done = p.onEvent(
+            event("tool/result", {
+                turn: 1,
+                step: 0,
+                message: {
+                    content: [
+                        {
+                            type: "tool-result",
+                            toolCallId: "background-call",
+                            content: [{ type: "text", text }],
+                        },
+                    ],
+                },
+            }),
+        );
+
+        expect(done[0]).toMatchObject({
+            sessionUpdate: "tool_call_update",
+            toolCallId: "background-call",
+            status: "completed",
+            _meta: { dsh: { toolResult: { value: typed } } },
+        });
+        expect(
+            (done[0] as unknown as { _meta: { dsh: { toolResult: unknown } } })._meta.dsh.toolResult,
+        ).toEqual({ value: typed });
+        expect((done[0] as Record<string, unknown>)["rawOutput"]).toEqual({ output: text, isError: false });
+    });
+
+    it("publishes a captured canonical tool value through generic metadata", () => {
+        const p = new SessionProjection();
+        p.recordToolResult("search-call", {
+            matches: [{ path: "/workspace/a.ts", line: 7 }],
+            truncated: false,
+        });
+        p.onEvent(event("tool/call", {
+            turn: 1,
+            step: 0,
+            callId: "search-call",
+            name: "grep_search",
+            arguments: '{"query":"needle"}',
+        }));
+
+        const done = p.onEvent(event("tool/result", {
+            turn: 1,
+            step: 0,
+            message: {
+                content: [{
+                    type: "tool-result",
+                    toolCallId: "search-call",
+                    content: [{ type: "text", text: "/workspace/a.ts:7:needle" }],
+                }],
+            },
+        }));
+
+        expect(done[0]).toMatchObject({
+            sessionUpdate: "tool_call_update",
+            toolCallId: "search-call",
+            _meta: {
+                dsh: {
+                    toolResult: {
+                        value: {
+                            matches: [{ path: "/workspace/a.ts", line: 7 }],
+                            truncated: false,
+                        },
+                    },
+                },
+            },
+        });
+        expect(
+            (done[0] as unknown as { _meta: { dsh: { toolResult: unknown } } })._meta.dsh.toolResult,
+        ).toEqual({
+            value: {
+                matches: [{ path: "/workspace/a.ts", line: 7 }],
+                truncated: false,
+            },
+        });
+    });
+
     it("streams command output onto a display terminal when the client supports one", () => {
         const p = new SessionProjection(undefined, { terminalOutput: true, cwd: "/ws" });
         const start = p.onEvent(


### PR DESCRIPTION
## Summary

- capture the structured `value` from DSH `tools/result` events before rendering
- expose it as `_meta.dsh.toolResult.value` on ACP tool call updates while preserving the normalized `content` and `rawOutput`
- reconstruct typed background and continuable acknowledgements when replaying durable history that predates the live observation

## Verification

- `npm run typecheck`
- `npm test` (153 passed, 1 skipped)

Fixes #9