### PR TITLE
fix: keep reasoning effort out of product settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ another provider.
 - **Tool calls** — ACP kinds, human titles, file locations, real diffs from fs-tool hunks, raw input/output; command output on a **display terminal** when the client supports one, fenced output otherwise.
 - **Permission presets as session modes** — `read-only` / `workspace-write` / `danger-full-access`, each a named `{sandbox, approval}` pair recorded as a durable session fact (also exposed as a config option for clients that only render those).
 - **Agent composition** — when the profile mounts `agentPresets`, an uncategorized config option `id: "agent"` lists the roster (`standard` / `code` / `minimal` / `cordis`, plus user copies). Switching rebuilds the agent live with history preserved. Authoring (copy/rm) stays on the Web settings page; there is no `/preset` slash.
-- **Live model catalog** — providers × models from the running composition (third-party providers added in the Web UI appear immediately), plus reasoning-effort selection that follows your product default.
+- **Live model catalog** — providers × models from the running composition (third-party providers added in the Web UI appear immediately), plus adapter-owned reasoning-effort options and defaults. An ACP effort choice is scoped to its session.
 - **Slash commands** — adapter built-ins (`/status`, `/model`) plus the harness command registry (`/compact`, `/goal`, `/permission`, `/plan`, …) executed without a model turn, plus **skills** (`/skill-name` — the harness's own invocation gesture). Login and logout are ACP methods, not chat commands.
 - **Plans & usage** — `todo_write` snapshots as ACP plans; token accounting as `usage_update` and per-turn usage.
 - **Sessions** — `session/resume` restores a durable session without replaying its transcript; `session/load` remains the full-history path. Also supports `session/list`, silent restore when a client prompts an old session after an agent restart, and titles as `session_info_update`. Multi-root sessions are not advertised: non-empty `additionalDirectories` on `session/new`, `session/resume`, or `session/load` return `Invalid params` until [dsh supports multiple workspace roots](https://github.com/deepseek-ai/deepseek-harness/discussions/2474).
@@ -233,7 +233,8 @@ another provider.
 ## Configuration
 
 Flags win over environment variables, which win over defaults. All optional —
-with no flags, sessions follow your product defaults (`settings.yaml`).
+with no route flags, provider and model follow your product defaults
+(`settings.yaml`); reasoning effort remains adapter/ACP-owned.
 
 | Flag | Env | Default | Purpose |
 |---|---|---|---|
@@ -242,7 +243,7 @@ with no flags, sessions follow your product defaults (`settings.yaml`).
 | `--model` | `DSH_MODEL` | product default | Model override |
 | `--max-tokens` | `DSH_MAX_TOKENS` | provider default | Per-request output-token cap |
 | `--permission-mode` | `DSH_PERMISSION_MODE` | `workspace-write` | Initial permission preset |
-| `--reasoning-effort` | `DSH_REASONING_EFFORT` | product default | `off` / `high` / `max` |
+| `--reasoning-effort` | `DSH_REASONING_EFFORT` | `high` | Adapter default; `off` / `high` / `max` |
 | — | `DEEPSEEK_API_KEY` | — | API credential (fallback to the credential store) |
 | — | `DEEPSEEK_BASE_URL` | DeepSeek endpoint | OpenAI-compatible endpoint override |
 | — | `DSH_ACP_DEBUG` | off | Verbose stderr diagnostics |

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -56,7 +56,7 @@ import {
 import type { Context } from "@deepseek-ai/cordis";
 import { credentialRef } from "@deepseek-ai/dsh-credentials";
 import type { Agent } from "@deepseek-ai/dsh-agent";
-import { ReasoningEffortId, type createUserMessage, type errorChain } from "@deepseek-ai/dsh-llm";
+import { type createUserMessage, type errorChain } from "@deepseek-ai/dsh-llm";
 import type { SessionId, SessionEvent } from "@deepseek-ai/dsh-session";
 import type { foldSessionTitle } from "@deepseek-ai/dsh-session-title";
 import type { setSandboxMode } from "@deepseek-ai/dsh-sandbox-policy";
@@ -331,27 +331,28 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
         label: string;
     }
 
-    /** The composition's default selection (agent-default-model → settings.yaml). */
-    const defaultSelection = (): { provider?: string; model?: string; reasoningEffort?: string } => {
+    /** The composition's default route (agent-default-model → settings.yaml). */
+    const defaultRoute = (): { provider?: string; model?: string } => {
         try {
-            return agentDefaultModel.currentSelection();
+            const { provider, model } = agentDefaultModel.currentSelection();
+            return {
+                ...(provider !== undefined ? { provider } : {}),
+                ...(model !== undefined ? { model } : {}),
+            };
         } catch (error: unknown) {
             logDebug(`agentDefaultModel.currentSelection failed: ${String(error)}`);
             return {};
         }
     };
 
-    /** Match Web: a successful session selection also becomes the live product default. */
-    const saveDefaultSelection = async (record: SessionRecord): Promise<void> => {
+    /** Match Web for the route only; reasoning effort is ACP session state. */
+    const saveDefaultModel = async (record: SessionRecord): Promise<void> => {
         const selected = ensureSelection(record)?.current;
         if (selected === undefined) return;
         try {
             await agentDefaultModel.saveSelection({
                 provider: selected.provider,
                 model: selected.model,
-                ...(selected.reasoningEffort === undefined
-                    ? {}
-                    : { reasoningEffort: ReasoningEffortId(selected.reasoningEffort) }),
             });
         } catch (error: unknown) {
             // The current-session switch remains valid when settings are
@@ -360,7 +361,7 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
         }
     };
 
-    const defaultProvider = (): string | undefined => config.provider ?? defaultSelection().provider;
+    const defaultProvider = (): string | undefined => config.provider ?? defaultRoute().provider;
 
     const encodeChoice = (provider: string | undefined, model: string): string =>
         provider === undefined || provider === defaultProvider() ? model : `${provider}::${model}`;
@@ -425,7 +426,7 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
         const model =
             record.model ??
             config.model ??
-            defaultSelection().model ??
+            defaultRoute().model ??
             logged?.model ??
             record.agent.options.model;
         return {
@@ -488,10 +489,9 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
 
     /**
      * Install (once per live agent) the mutable selection prompt assembly
-     * snapshots. Reads fall back to the logged header, then the session's
-     * route composed with the product-default reasoning effort (the Web UI
-     * saved selection), so an untouched session runs exactly what the other
-     * dsh entry points (web, headless) would run.
+     * snapshots. Reads fall back to the logged header, then only the
+     * session's route. Omitting reasoning effort here lets the owning adapter
+     * materialize its advertised default; product settings are not ACP state.
      */
     const ensureSelection = (record: SessionRecord): ModelSelectionRef | undefined => {
         const install = harness.installModelSelection;
@@ -505,15 +505,7 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
                 if (logged !== undefined) return logged;
                 const { provider, model } = routeOf(record);
                 if (provider === undefined || model === undefined) return undefined;
-                const defaults = defaultSelection();
-                // Effort applies when the route is the default selection's own
-                // model (or the default names no model): a explicitly pinned
-                // different model keeps its adapter-default behavior.
-                const effort =
-                    defaults.model === undefined || defaults.model === model
-                        ? defaults.reasoningEffort
-                        : undefined;
-                return { provider, model, ...(effort !== undefined ? { reasoningEffort: effort } : {}) };
+                return { provider, model };
             },
             set current(next: ModelSelectionValue | undefined) {
                 picked = next;
@@ -574,7 +566,7 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
             delete record.provider;
         }
         // The old selection ref died with the disposed agent's scope; reinstall
-        // immediately so the default reasoning effort keeps applying.
+        // it immediately under the new adapter-owned route and effort catalog.
         delete record.selection;
         const route = routeOf(record);
         const catalog = await effortCatalog(route.provider, route.model);
@@ -592,7 +584,7 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
                 ...(effort !== undefined ? { reasoningEffort: effort } : {}),
             };
         }
-        await saveDefaultSelection(record);
+        await saveDefaultModel(record);
         // Approval policy is agent-scoped state; re-apply it to the new agent.
         setApprovalPolicy(record, record.approvals);
     };
@@ -648,7 +640,7 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
         model: string | undefined,
         provider?: string,
     ): { provider?: string; model?: string; maxTokens?: number; interactionMode?: AcpInteractionMode } => {
-        const defaults = defaultSelection();
+        const defaults = defaultRoute();
         const resolvedProvider = provider ?? config.provider ?? defaults.provider;
         const resolvedModel = model ?? config.model ?? defaults.model;
         return withInteractionMode({
@@ -1106,7 +1098,7 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
         };
         const current = encodeChoice(
             record.provider,
-            record.model ?? config.model ?? defaultSelection().model ?? record.agent.options.model ?? "",
+            record.model ?? config.model ?? defaultRoute().model ?? record.agent.options.model ?? "",
         );
         if (current.length === 0) return [];
         // Adapter directory first: it carries human names and third-party
@@ -1191,9 +1183,6 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
             const preferred = [
                 record.effort,
                 loggedConfig(record)?.reasoningEffort,
-                // The user's saved product default (Web UI → settings.yaml),
-                // e.g. reasoningEffort: max, outranks the adapter's default.
-                defaultSelection().reasoningEffort,
                 efforts.defaultEffort,
             ].find(
                 (candidate): candidate is string => candidate !== undefined && known.has(candidate),
@@ -2062,7 +2051,6 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
                             reasoningEffort: value,
                         };
                         record.effort = value;
-                        await saveDefaultSelection(record);
                         break;
                     }
                     case "collaboration_mode": {

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -10,6 +10,7 @@
 
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -47,6 +48,7 @@ class AcpTestClient {
             // Host-default tests must not inherit the developer shell's
             // explicit per-process override.
             DSH_PERMISSION_MODE: undefined,
+            DSH_REASONING_EFFORT: undefined,
             ...(dshPath !== undefined ? { DSH_PATH: dshPath } : {}),
             ...(envPatch ?? {}),
         };
@@ -358,7 +360,7 @@ describe("dsh-acp Host-owned defaults", () => {
             .toMatchObject({ provider: "deepseek-official", model: "deepseek-v4-pro" });
     }, 90_000);
 
-    it("saves the selected model and effort as the default for later sessions", async () => {
+    it("saves the selected model but keeps effort scoped to its session", async () => {
         const sessionRoot = mkdtempSync(join(tmpdir(), "dsh-acp-default-model-sessions-"));
         const workspace = mkdtempSync(join(tmpdir(), "dsh-acp-default-model-workspace-"));
         roots.push(sessionRoot, workspace);
@@ -380,6 +382,8 @@ describe("dsh-acp Host-owned defaults", () => {
             configId: "effort",
             value: "max",
         });
+        expect(readFileSync(join(sessionRoot, "home", "settings.yaml"), "utf8"))
+            .not.toContain("reasoningEffort");
 
         const later = (await client.request("session/new", {
             cwd: workspace,
@@ -387,7 +391,68 @@ describe("dsh-acp Host-owned defaults", () => {
         })) as { configOptions: Array<Record<string, unknown>> };
         const options = new Map(later.configOptions.map((option) => [option["id"], option]));
         expect(options.get("model")).toMatchObject({ currentValue: "deepseek-v4-pro" });
-        expect(options.get("effort")).toMatchObject({ currentValue: "max" });
+        expect(options.get("effort")).toMatchObject({ currentValue: "high" });
+    }, 90_000);
+
+    it("ignores the persisted settings effort when assembling a prompt", async () => {
+        const sessionRoot = mkdtempSync(join(tmpdir(), "dsh-acp-settings-effort-sessions-"));
+        const workspace = mkdtempSync(join(tmpdir(), "dsh-acp-settings-effort-workspace-"));
+        const harnessHome = join(sessionRoot, "home");
+        roots.push(sessionRoot, workspace);
+        mkdirSync(harnessHome, { recursive: true });
+        writeFileSync(
+            join(harnessHome, "settings.yaml"),
+            [
+                "agent-default-model:",
+                "  provider: deepseek-official",
+                "  model: deepseek-v4-pro",
+                "  reasoningEffort: max",
+                "",
+            ].join("\n"),
+        );
+
+        const requestBodies: Array<Record<string, unknown>> = [];
+        const server = createServer((request, response) => {
+            let body = "";
+            request.setEncoding("utf8");
+            request.on("data", (chunk: string) => {
+                body += chunk;
+            });
+            request.on("end", () => {
+                requestBodies.push(JSON.parse(body) as Record<string, unknown>);
+                response.writeHead(400, { "content-type": "application/json" });
+                response.end(JSON.stringify({ error: { message: "fixture stop" } }));
+            });
+        });
+        await new Promise<void>((resolve, reject) => {
+            server.once("error", reject);
+            server.listen(0, "127.0.0.1", resolve);
+        });
+
+        try {
+            const address = server.address();
+            if (address === null || typeof address === "string") throw new Error("fixture server has no TCP address");
+            const client = new AcpTestClient(sessionRoot, workspace, undefined, {
+                DEEPSEEK_BASE_URL: `http://127.0.0.1:${address.port}`,
+            });
+            clients.push(client);
+
+            await client.request("initialize", { protocolVersion: 1 }, 60_000);
+            const created = (await client.request("session/new", {
+                cwd: workspace,
+                mcpServers: [],
+            })) as { sessionId: string };
+            await client.request("session/prompt", {
+                sessionId: created.sessionId,
+                prompt: [{ type: "text", text: "settings effort source probe" }],
+            }).catch(() => undefined);
+
+            expect(requestBodies[0]).toMatchObject({ reasoning_effort: "high" });
+        } finally {
+            await new Promise<void>((resolve, reject) => {
+                server.close((error) => error === undefined ? resolve() : reject(error));
+            });
+        }
     }, 90_000);
 
     it("restores the selected permission after the ACP Host restarts", async () => {


### PR DESCRIPTION
## Summary

- make the model adapter and ACP session the authoritative reasoning-effort sources
- stop reading `agent-default-model.reasoningEffort` while assembling new prompts
- stop persisting ACP effort changes to product settings while retaining provider/model route defaults
- cover both session scoping and stale-settings request assembly with regressions

## Test plan

- `npm run typecheck`
- `npm test` (156 passed, 1 skipped)