### PR TITLE
fix: replay the stored transcript on session/resume (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ another provider.
 - **Live model catalog** — providers × models from the running composition (third-party providers added in the Web UI appear immediately), plus reasoning-effort selection that follows your product default.
 - **Slash commands** — adapter built-ins (`/status`, `/model`) plus the harness command registry (`/compact`, `/goal`, `/permission`, `/plan`, …) executed without a model turn, plus **skills** (`/skill-name` — the harness's own invocation gesture). Login and logout are ACP methods, not chat commands.
 - **Plans & usage** — `todo_write` snapshots as ACP plans; token accounting as `usage_update` and per-turn usage.
-- **Sessions** — `session/resume` restores a durable session without replaying its transcript; `session/load` remains the full-history path. Also supports `session/list`, silent restore when a client prompts an old session after an agent restart, and titles as `session_info_update`. Multi-root sessions are not advertised: non-empty `additionalDirectories` on `session/new`, `session/resume`, or `session/load` return `Invalid params` until [dsh supports multiple workspace roots](https://github.com/deepseek-ai/deepseek-harness/discussions/2474).
+- **Sessions** — `session/resume` and `session/load` restore a durable session and replay its stored transcript; downstream clients reopen sessions with either method. Only a client that already renders the thread itself skips replay — it keeps prompting the old session id after an agent restart (silent restore, no replay). Also supports `session/list` and titles as `session_info_update`. Multi-root sessions are not advertised: non-empty `additionalDirectories` on `session/new`, `session/resume`, or `session/load` return `Invalid params` until [dsh supports multiple workspace roots](https://github.com/deepseek-ai/deepseek-harness/discussions/2474).
 - **MCP servers** — per-session `mcpServers` mount `@deepseek-ai/dsh-mcp-client` instances (stdio + streamable HTTP); tools join as `mcp__<server>__<tool>`; a failing server never takes the session down.
 - **Real cancellation** — `session/cancel` interrupts the live turn through the harness agent.
 
@@ -275,7 +275,7 @@ dsh-acp
         ├─ index.ts           sessions, prompts, cancel, modes, options,
         │                     commands, credentials, MCP mounts
         ├─ translate.ts       session-event → ACP update projection (pure)
-        ├─ history.ts         stored-log replay for session/load (pure)
+        ├─ history.ts         stored-log replay for session/load + resume (pure)
         └─ prompt.ts          ACP prompt blocks → harness content blocks (pure)
    ▼
 external or package-bundled dsh     (agent spine, llm, persistence, sandbox,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openma/deepseek-harness-acp",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openma/deepseek-harness-acp",
-      "version": "0.4.27",
+      "version": "0.4.28",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.4.27",
+  "version": "0.4.28",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openma-ai/deepseek-harness-acp.git"

--- a/src/bridge/history.ts
+++ b/src/bridge/history.ts
@@ -1,5 +1,5 @@
 /**
- * `session/load` history replay.
+ * Stored-log history replay (`session/load` and `session/resume`).
  *
  * The harness persists every session as an append-only event log; constructor
  * seeds do not re-fire the live `session/event` hook, so history replay reads
@@ -21,13 +21,15 @@ export interface ReplayResult {
     contextWindow: number | undefined;
 }
 
-export type ResumeMetadata = Pick<ReplayResult, "title" | "contextWindow">;
+export type RestoreMetadata = Pick<ReplayResult, "title" | "contextWindow">;
 
 /**
  * Fold only the state needed to continue a persisted session. Unlike
- * `buildReplay`, this never projects transcript events or retains ACP updates.
+ * `buildReplay`, this never projects transcript events or retains ACP updates;
+ * it backs the silent restore when a client keeps prompting an old session id
+ * after an agent restart (the client already renders the thread itself).
  */
-export function buildResumeMetadata(events: readonly HarnessEvent[]): ResumeMetadata {
+export function buildRestoreMetadata(events: readonly HarnessEvent[]): RestoreMetadata {
     let title: string | undefined;
     let contextWindow: number | undefined;
     for (const event of events) {

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -13,8 +13,8 @@
  * - `todo_write` plans, token usage, session titles
  * - real cancellation (`agent.cancel`), permission requests, sandbox-mode
  *   session modes, model switching via session config options
- * - `session/resume` without transcript replay, `session/load` with full
- *   history replay from JSONL persistence, `session/list` from the same store
+ * - `session/resume` and `session/load` both replay the stored transcript
+ *   from JSONL persistence, `session/list` from the same store
  */
 
 import { randomUUID } from "node:crypto";
@@ -89,7 +89,7 @@ import {
 } from "../auth.ts";
 import { openLocalAuthPage, startLocalAuthPage } from "../auth-page.ts";
 import { logDebug, logWarn } from "../log.ts";
-import { buildReplay, buildResumeMetadata, type ResumeMetadata } from "./history.ts";
+import { buildReplay, buildRestoreMetadata, type RestoreMetadata } from "./history.ts";
 import { LatestPublication } from "./latest-publication.ts";
 import {
     interactionModeFromClientMeta,
@@ -692,7 +692,8 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
      * Resume one persisted session into a live record: inspect the log,
      * optionally replay its history to the client, rebuild the agent with
      * its stored preset, and fold logged permission facts. Shared by
-     * `session/load` (replay: true) and silent restore (replay: false).
+     * `session/load` and `session/resume` (replay: true) and the silent
+     * restore when a client prompts an old session id (replay: false).
      */
     const restoreSession = async (
         sessionId: string,
@@ -719,7 +720,7 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
         } catch (error: unknown) {
             throw invalidParams(`session not found: ${sessionId} (${errorChain(error)})`);
         }
-        let restored: ResumeMetadata;
+        let restored: RestoreMetadata;
         if (options.replay) {
             const replay = buildReplay(events as unknown as HarnessEvent[]);
             restored = replay;
@@ -731,7 +732,7 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
                 });
             }
         } else {
-            restored = buildResumeMetadata(events as unknown as HarnessEvent[]);
+            restored = buildRestoreMetadata(events as unknown as HarnessEvent[]);
         }
         const presets = presetsService();
         const storedPreset = presetFromLog(storedHeader, events as unknown as { type?: string }[]);
@@ -1813,6 +1814,12 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
                 };
             },
 
+            // Downstream clients reopen durable sessions with `session/resume`
+            // (Martty `/resume`, session pickers) and render only what this
+            // adapter streams, so the stored transcript is replayed exactly as
+            // on `session/load`. A client that already renders its own thread
+            // never resumes: it keeps prompting the old session id, which
+            // silently restores without replay.
             async resumeSession(params: ResumeSessionRequest): Promise<ResumeSessionResponse> {
                 assertOpen();
                 await requireCredential(config.provider);
@@ -1820,7 +1827,7 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
                 validateAdditionalDirectories(params.additionalDirectories);
                 syncMcpServers(params.mcpServers, params.cwd);
                 requirePersistence();
-                const record = await restoreSession(params.sessionId, { replay: false, cwd: params.cwd });
+                const record = await restoreSession(params.sessionId, { replay: true, cwd: params.cwd });
                 const options = await configOptions(record);
                 return {
                     modes: modeState(record),

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -866,6 +866,17 @@ describe("dsh-acp server (e2e smoke)", () => {
         });
     }, 60_000);
 
+    it("persists a real user turn into the durable transcript", async () => {
+        // Adapter commands (/status) never reach the model, so their turns
+        // leave no transcript events behind. A real user prompt does — the
+        // model endpoint here is dead by design, and the failed turn still
+        // checkpoints its user/message, which history replay must reproduce.
+        await expect(client.request("session/prompt", {
+            sessionId,
+            prompt: [{ type: "text", text: "remember this turn for replay" }],
+        })).rejects.toThrow(/failed/);
+    }, 60_000);
+
     it("loads a persisted session from a fresh server process", async () => {
         // End the first server so the second owns the JSONL store exclusively.
         await client.close();
@@ -890,7 +901,7 @@ describe("dsh-acp server (e2e smoke)", () => {
         ).rejects.toThrow(/session not found/);
     }, 60_000);
 
-    it("resumes a persisted session without replaying its history", async () => {
+    it("replays the stored transcript when a session is resumed", async () => {
         await client.close();
         client = new AcpTestClient(sessionRoot, workspace);
         const initialized = (await client.request("initialize", { protocolVersion: 1 })) as Record<string, unknown>;
@@ -905,15 +916,33 @@ describe("dsh-acp server (e2e smoke)", () => {
         })) as Record<string, unknown>;
         expect(result["modes"]).toMatchObject({ currentModeId: "read-only" });
 
-        const replayKinds = new Set([
-            "user_message_chunk",
-            "agent_message_chunk",
-            "agent_thought_chunk",
-            "tool_call",
-            "tool_call_update",
-        ]);
-        expect(client.updatesFor(sessionId).filter((update) => replayKinds.has(String(update["sessionUpdate"])))).toEqual([]);
+        // Downstream clients that reopen durable sessions (Martty `/resume`)
+        // render only what this adapter streams, so resume replays the stored
+        // transcript the same way session/load does — including the real user
+        // turn persisted above.
+        const replayedKinds = (): Array<Record<string, unknown>> => client
+            .updatesFor(sessionId)
+            .filter((update) => {
+                const kind = String(update["sessionUpdate"]);
+                return kind === "user_message_chunk"
+                    || kind === "agent_message_chunk"
+                    || kind === "agent_thought_chunk"
+                    || kind === "tool_call"
+                    || kind === "tool_call_update";
+            });
+        let replayed = replayedKinds();
+        for (let attempt = 0; replayed.length === 0 && attempt < 80; attempt += 1) {
+            await new Promise((resolve) => setTimeout(resolve, 25));
+            replayed = replayedKinds();
+        }
+        expect(replayed).toContainEqual(
+            expect.objectContaining({
+                sessionUpdate: "user_message_chunk",
+                content: { type: "text", text: "remember this turn for replay" },
+            }),
+        );
 
+        // The resumed session accepts adapter commands again.
         await expect(client.request("session/prompt", {
             sessionId,
             prompt: [{ type: "text", text: "/status" }],
@@ -922,7 +951,10 @@ describe("dsh-acp server (e2e smoke)", () => {
 
     it("restores a persisted session on direct prompt without session/load", async () => {
         // Zed keeps threads across agent restarts and may prompt an old
-        // session id directly; the adapter restores it from the log.
+        // session id directly; the adapter restores it from the log. This
+        // silent path stays replay-free (the client already renders the
+        // thread) — replay happens only on explicit session/load or
+        // session/resume.
         await client.close();
         client = new AcpTestClient(sessionRoot, workspace);
         await client.request("initialize", { protocolVersion: 1 });
@@ -931,6 +963,12 @@ describe("dsh-acp server (e2e smoke)", () => {
             prompt: [{ type: "text", text: "/status" }],
         })) as Record<string, unknown>;
         expect(status["stopReason"]).toBe("end_turn");
+        // Silent restore must stay replay-free: the live /status turn never
+        // emits user_message_chunk, so one here would mean the stored
+        // transcript had been replayed behind the client's back.
+        expect(client.updatesFor(sessionId).filter(
+            (update) => update["sessionUpdate"] === "user_message_chunk",
+        )).toEqual([]);
         // Truly unknown ids still fail loudly.
         await expect(
             client.request("session/prompt", {

--- a/test/history.test.ts
+++ b/test/history.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildReplay, buildResumeMetadata } from "../src/bridge/history.ts";
+import { buildReplay, buildRestoreMetadata } from "../src/bridge/history.ts";
 import type { HarnessEvent } from "../src/bridge/translate.ts";
 
 const log: HarnessEvent[] = [
@@ -41,8 +41,8 @@ const log: HarnessEvent[] = [
 ];
 
 describe("buildReplay", () => {
-    it("folds resume metadata without constructing replay updates", () => {
-        expect(buildResumeMetadata(log)).toEqual({
+    it("folds restore metadata without constructing replay updates", () => {
+        expect(buildRestoreMetadata(log)).toEqual({
             title: "Fix the bug",
             contextWindow: 4096,
         });


### PR DESCRIPTION
Closes #14 — when a downstream client resumes a session (`session/resume`), the stored transcript is now replayed to it, exactly like `session/load`.

## Why

Downstream clients (Martty `/resume`, session pickers) reopen durable sessions with `session/resume` and render **only** what this adapter streams. With the no-replay resume shipped in v0.4.27 they got an empty thread and the notice "previous transcript was not replayed" (Martty's `⟲ resumed {id} — previous transcript was not replayed`).

Clients that already render their own thread never call `session/resume` — they keep prompting the old session id after an agent restart, and that silent restore path stays replay-free (unchanged). So replaying on explicit resume has no double-render downside on this adapter; it matches where ACP itself is heading (`replayFrom` on v2 resume).

## Changes

- `src/bridge/index.ts` — `session/resume` restores with `replay: true` (shared `restoreSession` path with `session/load`); silent prompt-restore remains `replay: false`
- `src/bridge/history.ts` — rename `buildResumeMetadata` → `buildRestoreMetadata` (it now backs only the silent no-replay restore); header documents replay for both methods
- `test/e2e.test.ts` — new "persists a real user turn" seed (adapter `/status` turns leave no transcript events, so replay was vacuous before); resume test now asserts the replayed `user_message_chunk`; silent-restore test locks in that it emits **no** replay
- README / docs updated

## Verification

- `npm run typecheck` ✓
- Full suite incl. host tree: **157 passed** (`DSH_ACP_TEST_HOST=$PWD npm test`)