### PR TITLE
fix: resolve shipped agent presets for the dsh 0.1.2 generation

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -35,30 +35,60 @@ function resolvedHostModule(ctx: Context, specifier: string): string {
     return specifier;
 }
 
-function shippedPresetRoot(ctx: Context): string {
+type PresetRoot = { path: string; trust: "system" };
+
+/**
+ * Where the four shipped presets live changed with the dsh generation:
+ *
+ * - dsh 0.1.1 ships them inside the meta package at
+ *   `@deepseek-ai/dsh/config/agent-presets`;
+ * - dsh 0.1.2 ships them inside `@deepseek-ai/dsh-agent-presets/presets` and
+ *   prepends that root itself via its `includeShippedRoot` default, so the
+ *   mount must pass no explicit roots at all.
+ *
+ * Returns the explicit system root for the legacy layout, an empty list when
+ * the resolved roster package self-ships its presets, and throws only when
+ * neither layout can be resolved (the mount would otherwise silently serve an
+ * empty roster).
+ */
+function shippedPresetRoots(ctx: Context): PresetRoot[] {
     const anchors = [ctx.baseUrl, import.meta.url].filter((value): value is string => typeof value === "string");
     for (const anchor of anchors) {
         try {
             const manifest = createRequire(anchor).resolve("@deepseek-ai/dsh/package.json");
             const root = join(dirname(manifest), "config", "agent-presets");
-            if (existsSync(root)) return root;
+            if (existsSync(root)) return [{ path: root, trust: "system" }];
         } catch {
             // Try the next resolution anchor.
         }
     }
-    throw new Error("dsh-acp-plugin: cannot resolve the dsh shipped agent presets");
+    for (const anchor of anchors) {
+        try {
+            const manifest = createRequire(anchor).resolve("@deepseek-ai/dsh-agent-presets/package.json");
+            if (existsSync(join(dirname(manifest), "presets"))) return [];
+        } catch {
+            // Try the next resolution anchor.
+        }
+    }
+    throw new Error(
+        "dsh-acp-plugin: cannot resolve the dsh shipped agent presets (looked for @deepseek-ai/dsh/config/agent-presets and a self-shipping @deepseek-ai/dsh-agent-presets)",
+    );
 }
 
 async function mountService(
     ctx: Context,
     service: string,
     specifier: string,
-    config?: unknown,
+    config?: unknown | (() => unknown),
 ): Promise<void> {
     if (ctx.get(service) !== undefined) return;
+    // A config factory defers resolution to the mount that actually needs it:
+    // a composition that already provides the service never pays for (or can
+    // fail on) the fallback's preset-root discovery.
+    const resolved = typeof config === "function" ? config() : config;
     const exports = await ctx.loader.import(resolvedHostModule(ctx, specifier));
     const plugin = ctx.loader.unwrapExports(exports);
-    await ctx.plugin(plugin, config);
+    await ctx.plugin(plugin, resolved);
     if (ctx.get(service) === undefined) {
         throw new Error(`dsh-acp-plugin: ${specifier} did not provide ${service}`);
     }
@@ -66,9 +96,14 @@ async function mountService(
 
 export async function apply(ctx: Context, config: Config = {}): Promise<void> {
     if (ctx.get("acpServer") !== undefined) return;
-    await mountService(ctx, "agentPresets", "@deepseek-ai/dsh-agent-presets", {
-        default: "standard",
-        roots: [{ path: shippedPresetRoot(ctx), trust: "system" }],
+    await mountService(ctx, "agentPresets", "@deepseek-ai/dsh-agent-presets", () => {
+        const roots = shippedPresetRoots(ctx);
+        return {
+            default: "standard",
+            // dsh 0.1.2's roster self-ships its presets (includeShippedRoot);
+            // passing the legacy root there would duplicate the roster.
+            ...(roots.length > 0 ? { roots } : {}),
+        };
     });
     await mountService(ctx, "dynamicCordisRunner", "@deepseek-ai/dsh-cordis-host-runner");
     await ctx.plugin(server, config);

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -46,4 +46,38 @@ describe("embeddable ACP Host plugin", () => {
         ]);
         expect(services.has("acpServer")).toBe(true);
     });
+
+    it("mounts only the ACP server when the surface already provides agentPresets and dynamicCordisRunner", async () => {
+        // dsh 0.1.2-era surfaces (and profiles that carry the ACP bundle rows)
+        // already supply both Host services; the fallback mount must be skipped
+        // entirely so its preset-root discovery can never run or fail.
+        const imports: string[] = [];
+        const services = new Map<string, unknown>();
+        const ctx = {
+            baseUrl: import.meta.url,
+            get(name: string) {
+                return services.get(name);
+            },
+            loader: {
+                async import(specifier: string) {
+                    imports.push(specifier);
+                    throw new Error(`unexpected fallback import of ${specifier}`);
+                },
+                unwrapExports(exports: unknown) {
+                    return exports;
+                },
+            },
+            async plugin(plugin: unknown) {
+                if ((plugin as { name?: string }).name === "acp-server") services.set("acpServer", {});
+            },
+        };
+        services.set("agentPresets", {});
+        services.set("dynamicCordisRunner", {});
+        const plugin = await import("../src/plugin.ts");
+
+        await plugin.apply(ctx as never);
+
+        expect(imports).toEqual([]);
+        expect(services.has("acpServer")).toBe(true);
+    });
 });


### PR DESCRIPTION
## Problem

`dsh --profile martty` (Martty TUI profile, dsh CLI 0.1.2-rc.1) fails at boot:

```
@openma/deepseek-harness-tui/creator-overlay: pending (waiting for services: agentPresets, dynamicCordisRunner)
@openma/deepseek-harness-tui/runner: pending (waiting for service: acpServer)
```

The profile mounts this plugin to fill the Host services dsh-base leaves to a surface (agent presets, dynamic Cordis runner) plus `acpServer`. The fallback `agentPresets` mount always resolved the shipped preset root from `@deepseek-ai/dsh/config/agent-presets`, which only exists in the dsh 0.1.1 layout. **dsh 0.1.2 ships the presets inside `@deepseek-ai/dsh-agent-presets/presets`** and prepends them itself via the `includeShippedRoot` default.

The throw happened inside a nested plugin that had already been awaited, so it stayed silent; the boot audit then only saw the three services never appear.

## Fix

- `shippedPresetRoots()` resolves both layouts: the legacy `@deepseek-ai/dsh/config/agent-presets` root when present, otherwise no explicit roots so the resolved roster's own shipped root (`includeShippedRoot`) applies.
- The mount config is now evaluated lazily (config factory), so a composition that already provides `agentPresets` never runs — or fails on — preset-root discovery.
- Added a unit test covering the already-provided-services path (fallback mount fully skipped).

## Verification

- `npm run typecheck`, `vitest run test/plugin.test.ts` (2/2) pass.
- Martty `profile-install-matrix` (5 cases, dsh 0.1.1-rc.2) passes.
- Boot smoke of a martty profile on dsh 0.1.2-rc.1 now completes ACP initialize/session-new: `{"marker":"PROFILE_SMOKE_OK","preset":"standard"}`.

Note: independent of #15. Merge order only matters for the v0.4.28 tag: tag the merged main *after* both land so the released 0.4.28 includes both fixes.