### PR TITLE
fix: preserve ACP events and question routing in Web hosts

### DIFF
--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -2249,14 +2249,9 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
     // Transport wiring and teardown                                       //
     // ------------------------------------------------------------------ //
 
-    const raw: Stream =
-        config.stream ??
-        ndJsonStream(
-            Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
-            Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>,
-        );
-    const stream = muxAcpStream(raw, rpc);
-    conn = new AgentSideConnection(makeAgent, stream);
+    // Complete fallible plugin setup before the SDK starts reading requests.
+    // Cordis rolls back listeners on failure, but cannot stop an unowned SDK
+    // connection that was already started (e.g. a legacy Web provider clash).
     await ctx.plugin(userQuestionsPlugin, {
         formSupported: () => clientElicitationForm,
         sessionIdForRequest: (request) => {
@@ -2302,6 +2297,17 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
         return quiescing;
     };
 
+    ctx.effect(() => quiesce, "acp-bridge.connection");
+
+    const raw: Stream =
+        config.stream ??
+        ndJsonStream(
+            Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+            Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>,
+        );
+    const stream = muxAcpStream(raw, rpc);
+    conn = new AgentSideConnection(makeAgent, stream);
+
     void conn.closed
         .catch((error: unknown) => {
             logWarn(`connection closed with an error: ${String(error)}`);
@@ -2310,6 +2316,4 @@ export async function apply(ctx: Context, config: AcpBridgeConfig = {}): Promise
         .catch((error: unknown) => {
             logWarn(`connection-close teardown failed: ${String(error)}`);
         });
-
-    ctx.effect(() => quiesce, "acp-bridge.connection");
 }

--- a/src/bridge/legacy-user-questions.ts
+++ b/src/bridge/legacy-user-questions.ts
@@ -1,0 +1,46 @@
+import { symbols } from "@deepseek-ai/cordis";
+import { UserQuestionError, type AskUserQuestionRequest, type AskUserQuestionAnswer } from "@deepseek-ai/dsh-user-questions";
+
+type Ask = (request: AskUserQuestionRequest) => Promise<AskUserQuestionAnswer>;
+type Route = (request: AskUserQuestionRequest, next: () => Promise<AskUserQuestionAnswer>) => Promise<AskUserQuestionAnswer>;
+interface LegacyService {
+    ask: Ask;
+    provider?: { ask: Ask };
+}
+
+/**
+ * 0.1.1's singleton provider predates the user-questions/request middleware.
+ * Keep its ask() validation and provider lifecycle intact: only the receiver
+ * of this invocation sees a routed provider. No shared provider is replaced,
+ * so Web can unregister/re-register while ACP connections remain active.
+ * The private `provider` layout is confined to this legacy capability shim.
+ */
+export function routeLegacyQuestions(service: object, route: Route): (() => void) | undefined {
+    const target = ((service as Record<PropertyKey, unknown>)[symbols.original] ?? service) as LegacyService;
+    if (!("provider" in target) || typeof target.ask !== "function") return undefined;
+    const descriptor = Object.getOwnPropertyDescriptor(target, "ask");
+    const originalAsk = target.ask;
+    const routedAsk: Ask = function (this: LegacyService, request) {
+        const receiver = this;
+        const provider = {
+            ask: (question: AskUserQuestionRequest) => route(question, () => {
+                const fallback = receiver.provider;
+                if (fallback === undefined) {
+                    throw new UserQuestionError("no user-questions provider is registered", "NO_PROVIDER");
+                }
+                return fallback.ask(question);
+            }),
+        };
+        return originalAsk.call(new Proxy(receiver, {
+            get(object, property, proxy) {
+                return property === "provider" ? provider : Reflect.get(object, property, proxy);
+            },
+        }), request);
+    };
+    Object.defineProperty(target, "ask", { configurable: true, writable: true, value: routedAsk });
+    return () => {
+        if (target.ask !== routedAsk) return;
+        if (descriptor === undefined) delete (target as Partial<LegacyService>).ask;
+        else Object.defineProperty(target, "ask", descriptor);
+    };
+}

--- a/src/bridge/user-questions.ts
+++ b/src/bridge/user-questions.ts
@@ -1,3 +1,4 @@
+import { routeLegacyQuestions } from "./legacy-user-questions.ts";
 import type {
     CreateElicitationRequest,
     CreateElicitationResponse,
@@ -213,7 +214,7 @@ export function installAcpUserQuestionProvider(
             registerProvider?: (provider: { ask: typeof ask }) => () => void;
         };
         const disposeProvider = typeof legacy.registerProvider === "function"
-            ? legacy.registerProvider({ ask })
+            ? routeLegacyQuestions(service, ask) ?? legacy.registerProvider({ ask })
             : (service as unknown as { ctx: Context }).ctx.root.on("user-questions/request", ask);
         router = { routes, disposeProvider };
         routers.set(owner, router);

--- a/src/bridge/user-questions.ts
+++ b/src/bridge/user-questions.ts
@@ -215,7 +215,7 @@ export function installAcpUserQuestionProvider(
         };
         const disposeProvider = typeof legacy.registerProvider === "function"
             ? routeLegacyQuestions(service, ask) ?? legacy.registerProvider({ ask })
-            : (service as unknown as { ctx: Context }).ctx.root.on("user-questions/request", ask);
+            : (service as unknown as { ctx: Context }).ctx.root.on("user-questions/request", ask, { prepend: true });
         router = { routes, disposeProvider };
         routers.set(owner, router);
     }

--- a/test/bridge-startup.test.ts
+++ b/test/bridge-startup.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { Context } from "@deepseek-ai/cordis";
+import { UserQuestionError } from "@deepseek-ai/dsh-user-questions";
+import * as bridge from "../src/bridge/index.ts";
+
+describe("ACP bridge startup", () => {
+    it("leaves the transport untouched when question-provider setup fails", async () => {
+        const ctx = new Context();
+        // Simulate a question backend rejecting registration during startup.
+        // All other services are idle: no ACP request should reach them.
+        for (const name of bridge.inject) ctx.provide(name, {});
+        ctx.set("userQuestions", {
+            registerProvider() {
+                throw new UserQuestionError("a user-questions provider is already registered", "DUPLICATE_PROVIDER");
+            },
+        });
+        const errors = vi.spyOn(ctx.logger, "error").mockImplementation(() => {});
+        const input = new TransformStream();
+        const output = new TransformStream();
+        const fiber = ctx.plugin(bridge, {
+            stream: { readable: input.readable, writable: output.writable },
+            harness: {} as bridge.BridgeHarness,
+        });
+        try {
+            await expect(Promise.resolve(fiber)).rejects.toMatchObject({ code: "DUPLICATE_PROVIDER" });
+            // Starting the SDK prematurely locks these streams even after
+            // Cordis rolls back the failed plugin and removes its listeners.
+            expect(input.readable.locked).toBe(false);
+            expect(output.writable.locked).toBe(false);
+        } finally {
+            await ctx.fiber.dispose();
+            errors.mockRestore();
+        }
+    });
+});

--- a/test/legacy-user-questions.test.ts
+++ b/test/legacy-user-questions.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { Context, Service } from "@deepseek-ai/cordis";
+import { UserQuestionError, type AskUserQuestionRequest, type AskUserQuestionAnswer } from "@deepseek-ai/dsh-user-questions";
+import { installAcpUserQuestionProvider } from "../src/bridge/user-questions.ts";
+
+type Provider = { ask(request: AskUserQuestionRequest): Promise<AskUserQuestionAnswer> };
+// The released 0.1.1 service contract, including validation before dispatch.
+class LegacyQuestions extends Service {
+    provider: Provider | undefined;
+    constructor(ctx: Context) { super(ctx, "userQuestions"); }
+    registerProvider(provider: Provider) {
+        if (this.provider) throw new UserQuestionError("provider exists", "DUPLICATE_PROVIDER");
+        this.provider = provider;
+        return () => { this.provider = undefined; };
+    }
+    async ask(request: AskUserQuestionRequest) {
+        if (request.signal?.aborted) throw new UserQuestionError("aborted", "ASK_ABORTED");
+        if (!request.questions.length) throw new UserQuestionError("empty", "EMPTY_QUESTIONS");
+        if (!this.provider) throw new UserQuestionError("missing", "NO_PROVIDER");
+        return this.provider.ask(request);
+    }
+}
+const answer = (custom: string) => ({ answers: [{ id: "q", selected: [], custom }] });
+const request = (id: string): AskUserQuestionRequest => ({ questions: [{ id, question: "Question?" }] });
+
+describe("legacy Web and ACP question coexistence", () => {
+    it("routes two ACP connections independently while retaining Web registration and reload", async () => {
+        const ctx = new Context();
+        await ctx.plugin(LegacyQuestions);
+        const service = ctx.userQuestions as unknown as LegacyQuestions;
+        let stopWeb = service.registerProvider({ ask: async () => answer("web") });
+        const stops: Array<() => void> = [];
+        try {
+            for (const id of ["a", "b"]) stops.push(installAcpUserQuestionProvider(service as never, {
+                formSupported: () => true,
+                sessionIdForRequest: r => r.questions[0]?.id === id ? id : undefined,
+                create: async () => ({ action: "accept", content: { question_0: id } }),
+            }));
+            expect(await service.ask(request("a"))).toEqual({ answers: [{ id: "a", selected: [], custom: "a" }] });
+            expect(await service.ask(request("b"))).toEqual({ answers: [{ id: "b", selected: [], custom: "b" }] });
+            expect(await service.ask(request("web"))).toEqual(answer("web"));
+            stops[0]!();
+            expect(await service.ask(request("b"))).toEqual({ answers: [{ id: "b", selected: [], custom: "b" }] });
+            stopWeb();
+            await expect(service.ask(request("web"))).rejects.toMatchObject({ code: "NO_PROVIDER" });
+            expect(await service.ask(request("b"))).toEqual({ answers: [{ id: "b", selected: [], custom: "b" }] });
+            stopWeb = service.registerProvider({ ask: async () => answer("reloaded-web") });
+            expect(await service.ask(request("web"))).toEqual(answer("reloaded-web"));
+            stops[1]!();
+            expect(await service.ask(request("b"))).toEqual(answer("reloaded-web"));
+        } finally {
+            stops.forEach(stop => stop()); stopWeb(); await ctx.fiber.dispose();
+        }
+    });
+    it("keeps host validation before ACP routing, even without a Web provider", async () => {
+        const ctx = new Context(); await ctx.plugin(LegacyQuestions);
+        const stop = installAcpUserQuestionProvider(ctx.userQuestions, {
+            formSupported: () => true, sessionIdForRequest: () => "acp",
+            create: async () => ({ action: "accept", content: { question_0: "yes" } }),
+        });
+        try {
+            await expect(ctx.userQuestions.ask({ questions: [] })).rejects.toMatchObject({ code: "EMPTY_QUESTIONS" });
+            await expect(ctx.userQuestions.ask({ ...request("q"), signal: AbortSignal.abort() })).rejects.toMatchObject({ code: "ASK_ABORTED" });
+        } finally { stop(); await ctx.fiber.dispose(); }
+    });
+});

--- a/test/user-questions.test.ts
+++ b/test/user-questions.test.ts
@@ -186,6 +186,23 @@ describe("ACP user-question elicitation", () => {
         });
     });
 
+    it("routes owned questions before an existing Web handler and delegates other questions", async () => {
+        const ctx = new Context();
+        await ctx.plugin(UserQuestionService);
+        ctx.on("user-questions/request", async () => ({ answers: [{ id: "web", selected: [], custom: "web" }] }));
+        const dispose = subject.installAcpUserQuestionProvider!(ctx.userQuestions, {
+            formSupported: () => true,
+            sessionIdForRequest: request => request.questions[0]?.id === "acp" ? "session" : undefined,
+            create: async () => ({ action: "accept", content: { question_0: "acp" } }),
+        });
+        try {
+            await expect(ctx.userQuestions.ask({ questions: [{ id: "acp", question: "Where?" }] }))
+                .resolves.toEqual({ answers: [{ id: "acp", selected: [], custom: "acp" }] });
+            await expect(ctx.userQuestions.ask({ questions: [{ id: "web", question: "Where?" }] }))
+                .resolves.toEqual({ answers: [{ id: "web", selected: [], custom: "web" }] });
+        } finally { dispose(); await ctx.fiber.dispose(); }
+    });
+
     it("registers the ACP client as the active user-questions provider", async () => {
         const ctx = new Context();
         const fiber = ctx.plugin(UserQuestionService);


### PR DESCRIPTION
Fixes #18.

In legacy Web hosts, the existing singleton user-question provider made ACP registration fail after its transport had started. Cordis removed the bridge's event listeners, while the connection kept accepting prompts: turns persisted normally but ACP returned empty output and `cancelled`.

- Complete question-provider setup and register teardown before starting the ACP transport.
- Route legacy questions per invocation through ACP when it owns the session, otherwise through the current Web provider. Original host validation and the Web registration lifecycle remain in place. The compatibility shim is isolated to the legacy `provider` field layout.
- Prepend the newer event-based ACP router so Web does not consume ACP-owned questions first; unrelated requests continue to Web.

Validation: regression tests for startup rollback, legacy multi-client routing and Web provider reload, validation errors, and newer Web-handler precedence; typecheck/build; real Web probes on dsh 0.1.1-rc.2 and 0.1.2-rc.1 exercising text replies, end_turn, form elicitation, multiple connections, disposal and reconnect.

Excludes the separate write-ownership work in #17. No release/version bump.
